### PR TITLE
fix: should use Figure instead of image AST node

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ const fs = require('fs')
 const tmpObj = tmp.fileSync({ mode: 0o644, prefix: 'mermaid-filter-', postfix: '.err' })
 const errorLog = fs.createWriteStream(tmpObj.name)
 
-pandoc.toJSONFilter(function (type, value, format, meta) {
+pandoc.toJSONFilter(function (ele,format,meta) {
   // Redirect stderr to a globally created writeable stream
   process.stderr.write = errorLog.write.bind(errorLog)
-  return utils.mermaid(type, value, format, meta)
+  return utils.mermaid(ele.t, ele.c, format, meta)
 })

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -134,13 +134,20 @@ function mermaid (type, value, _format, _meta) {
 
   const fig = id.startsWith('fig:') ? 'fig:' : ''
 
-  return pandoc.Para([
-    pandoc.Image(
-      [id, imageClasses, []],
-      [pandoc.Str(options.caption)],
-      [newPath, fig]
-    )
-  ])
+  return pandoc.Figure(
+    [id,imageClasses, []],
+    // caption=[Array<inline>,Array<block>]
+    [undefined, [
+        pandoc.Plain([pandoc.Str(options.caption)])
+    ]],
+    [pandoc.Plain(
+        [pandoc.Image(
+            [id, imageClasses, []],
+            [pandoc.Str(options.caption)],
+            [newPath, fig]
+        )]
+    )]
+  );
 }
 function mv (from, to) {
   const readStream = fs.createReadStream(from)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mermaid-js/mermaid-cli": "^10",
         "imgur": "^0.3.1",
         "minimist": ">=0.2.1",
-        "pandoc-filter": "^0.1.3",
+        "pandoc-filter": "^2.2.0",
         "sanitize-filename": "1.6.1",
         "tmp": "^0.0.28"
       },
@@ -3596,11 +3596,11 @@
       }
     },
     "node_modules/get-stdin": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz",
-      "integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/get-stream": {
@@ -6155,14 +6155,14 @@
       }
     },
     "node_modules/pandoc-filter": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/pandoc-filter/-/pandoc-filter-0.1.8.tgz",
-      "integrity": "sha512-vUe/6vbKX/X+7utsn5bgNXkq7G/NOfIRVguOh8LQG8wwnoqjgcsJH4xvvRRaHbUWgsAf6OQAGbPTeOsPoLwVGQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pandoc-filter/-/pandoc-filter-2.2.0.tgz",
+      "integrity": "sha512-mtjZfaiyONjN8HigU1XCoGDcadMmBwYtjAL2ol0vaY4qiOWmtCaVGJIa1gglKk7VSwYgAEfuE+5nvj/G3jLRBg==",
       "dependencies": {
-        "get-stdin": "~0.1.0"
+        "get-stdin": "~7.0.0"
       },
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=7.6.0"
       }
     },
     "node_modules/parent-module": {
@@ -10173,9 +10173,9 @@
       "dev": true
     },
     "get-stdin": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz",
-      "integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ=="
     },
     "get-stream": {
       "version": "5.2.0",
@@ -12025,11 +12025,11 @@
       "dev": true
     },
     "pandoc-filter": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/pandoc-filter/-/pandoc-filter-0.1.8.tgz",
-      "integrity": "sha512-vUe/6vbKX/X+7utsn5bgNXkq7G/NOfIRVguOh8LQG8wwnoqjgcsJH4xvvRRaHbUWgsAf6OQAGbPTeOsPoLwVGQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pandoc-filter/-/pandoc-filter-2.2.0.tgz",
+      "integrity": "sha512-mtjZfaiyONjN8HigU1XCoGDcadMmBwYtjAL2ol0vaY4qiOWmtCaVGJIa1gglKk7VSwYgAEfuE+5nvj/G3jLRBg==",
       "requires": {
-        "get-stdin": "~0.1.0"
+        "get-stdin": "~7.0.0"
       }
     },
     "parent-module": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@mermaid-js/mermaid-cli": "^10",
     "imgur": "^0.3.1",
     "minimist": ">=0.2.1",
-    "pandoc-filter": "^0.1.3",
+    "pandoc-filter": "^2.2.0",
     "sanitize-filename": "1.6.1",
     "tmp": "^0.0.28"
   },

--- a/test.md
+++ b/test.md
@@ -17,10 +17,8 @@ sequenceDiagram
     John-->>Alice: Great!
 ```
 ## fig ref
-```{.mermaid #fig:ref caption="Caption" format=png loc=img/child alt="should have id of fig:ref"}
-
 If an id starts with `fig:`, then `title` attribute is set to `fig:`
-
+```{.mermaid #fig:ref caption="Caption" format=png loc=img/child alt="should have id of fig:ref"}
 sequenceDiagram
     Note right of John: png with id as attr
     Alice->>John: Hello John, how are you?


### PR DESCRIPTION
Using the latest version, I cannot see caption in docx output, and the figure is made inline with wrong style(Body, should be Captioned Figure).
That's because `Image` is inline node, while `Figure` is a block node consists of `(FigureCaption,Array<block>)`.
Pandoc auto-generated AST use such structure, only so can the caption be displayed in docx output (also applies to HTML output in my test).
Below is a piece of auto-gen AST:
```
Figure
    ( "superfig" , [] , [] )
    (Caption
       Nothing
       [ Plain
           [ Str "caption"
           , Space
           , Str "text\22270\24335\20449\24687"
           ]
       ])
    [ Plain
        [ Image
            ( "" , [] , [] )
            [ Str "caption"
            , Space
            , Str "text\22270\24335\20449\24687"
            ]
            ( "/home/zyc/Pictures/whu-logo.png" , "" )
        ]
    ]
```
---
Btw, the pandoc-filter dependency is too old, I have to manually add a `Figure=elt('Figure',3)` item to its exports.